### PR TITLE
Numeric fallback for sorted(NoneType)

### DIFF
--- a/html/address.item.html
+++ b/html/address.item.html
@@ -282,7 +282,7 @@
        </td>
        <td tal:condition="not:context/address">
          <span tal:content="structure python:utils.new_property
-          (context, db, 'address', -1, 'country').field 
+          (context, db, 'address', -1, 'country').field
           (size=4, onChange=onch)"/>
            -
          <span tal:content="structure python:utils.new_property
@@ -326,7 +326,7 @@
       <td tal:content="structure context/city/field"/>
      </tr>
      <tr tal:condition="python:'province' in props">
-      <th tal:content="structure python:utils.fieldname 
+      <th tal:content="structure python:utils.fieldname
           (db, classname, 'province')" />
       <td tal:content="structure context/province/field"/>
      </tr>
@@ -386,7 +386,7 @@
         </tr>
         <tr tal:repeat="ct python:sorted
             ( context.contacts
-            , key = lambda x : (x.contact_type.order, x.contact)
+            , key = lambda x : (x.contact_type.order or 0, x.contact)
             )">
          <th style="vertical-align:top;text-align:left"
              tal:content="structure python:utils.ExtProperty

--- a/html/support.item.html
+++ b/html/support.item.html
@@ -342,7 +342,7 @@
           ( [c for c in context.customer.contacts
              if c.contact_type.name != 'Email'
             ]
-          , key = lambda x : (x.contact_type.order, x.contact)
+          , key = lambda x : (x.contact_type.order or 0, x.contact)
           )">
        <th style="vertical-align:top"
            tal:content="structure python:utils.ExtProperty

--- a/html/user.item.html
+++ b/html/user.item.html
@@ -178,7 +178,7 @@
         </tr>
         <tr tal:repeat="ct python:sorted
             ( context.contacts
-            , key = lambda x : (x.contact_type.order, x.order, x.contact)
+            , key = lambda x : (x.contact_type.order or 0, x.order or 0, x.contact)
             )">
          <th tal:content="structure python:utils.ExtProperty
              (utils, ct.contact_type, item = ct).formatlink () + '&nbsp;'"/>


### PR DESCRIPTION
user7085 on TTT has no sorted value on a contact item, throwing as error.
`<class 'TypeError'>: '<' not supported between instances of 'float' and 'NoneType'`
Simple numeric 0 fallback for falsy values.