### PR TITLE
Invalid Transition reasons unclear

### DIFF
--- a/detectors/time_record.py
+++ b/detectors/time_record.py
@@ -386,7 +386,7 @@ def check_daily_record (db, cl, nodeid, new_values):
                ):
             msg = "Invalid Transition"
             if old_status == 'open':
-                if 'status' == 'submitted':
+                if status == 'submitted':
                     if not is_hr and user != uid:
                         msg = _ ("Permission denied")
                     elif not time_records_consistent (db, dr):
@@ -395,7 +395,7 @@ def check_daily_record (db, cl, nodeid, new_values):
                         msg = _ ("Inkonsistent attendance records")
                     elif vs_has_valid or vs_has_open:
                         msg = _ ("Leave submission exists")
-                elif 'status' == 'leave':
+                elif status == 'leave':
                     msg = _ ("No accepted leave submission")
             elif old_status == 'leave':
                 msg = _ ("Leave submission not cancelled")


### PR DESCRIPTION
The reason for invalid transition upon submission was not clear due to old status not properly referenced.